### PR TITLE
Remove unary references in integer arithmetic

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,3 +13,6 @@
 
 # Any nix code
 *.nix @MatthewCroughan @nixinator @DarthPJB
+
+# Any Coq code
+*.v @AHartNtkn

--- a/src/coq-tinyram.opam
+++ b/src/coq-tinyram.opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 name: "coq-tinyram"
 version: "dev"
-maintainer: "Quinn Dougherty <quinn.dougherty@platonic.systems>"
+maintainer: "Anthony Hart <anthony.hart@platonic.systems>"
 synopsis: "https://www.scipr-lab.org/doc/TinyRAM-spec-2.000.pdf"
 
 homepage: "https://github.com/Orb-Labs/coq-tinyram"
@@ -22,7 +22,8 @@ depends: [
   "dune" {>= "2.6"}
 ]
 authors: [
-  "Quinn Dougherty <quinn.dougherty@platonic.systems"
+  "Anthony Hart <anthony.hart@platonic.systems>"
+  "Quinn Dougherty <quinn.dougherty@platonic.systems>"
 ]
 
 tags: "org:orbis"

--- a/src/theories/Machine/Denotations.v
+++ b/src/theories/Machine/Denotations.v
@@ -139,7 +139,7 @@ Module TinyRAMDenotations (Params : TinyRAMParameters).
           let resl := snd res in
           trigger (SetReg ri resl) ;;
           (*""" flag is set to 1 if [rj]u * [A]u ∈ U_W and to 0 otherwise. """*)
-          trigger (SetFlag (bv_eq resh (const b0 _))) ;;
+          trigger (SetFlag (negb (bv_eq resh (const b0 _)))) ;;
           trigger IncPC
 
         | umulhI ri rj =>
@@ -148,7 +148,7 @@ Module TinyRAMDenotations (Params : TinyRAMParameters).
           let resh := fst (splitat _ (bv_mul regj A)) in
           trigger (SetReg ri resh) ;;
           (*""" flag is set to 1 if [rj]u * [A]u ∈ U_W and to 0 otherwise. """*)
-          trigger (SetFlag (bv_eq resh (const b0 _))) ;;
+          trigger (SetFlag (negb (bv_eq resh (const b0 _)))) ;;
           trigger IncPC
 
         | smulhI ri rj =>
@@ -161,8 +161,8 @@ Module TinyRAMDenotations (Params : TinyRAMParameters).
           let resh := fst (splitat _ (bv_abs sres)) in
           trigger (SetReg ri (wuncast (sign :: resh))) ;;
           (*""" flag is set to 1 if [rj]s x [A]s ∈ [...] {-2^(W-1), ..., 0, 1, ..., 2^(W-1) - 1} """ *)
-          trigger (SetFlag (andb (- 2 ^ (of_nat wordSize - 1) <=? mjA) 
-                                 (mjA <? 2 ^ (of_nat wordSize - 1)))%Z) ;;
+          trigger (SetFlag (negb (andb (- 2 ^ (of_nat wordSize - 1) <=? mjA) 
+                                 (mjA <? 2 ^ (of_nat wordSize - 1)))%Z)) ;;
           trigger IncPC
 
         | udivI ri rj =>

--- a/src/theories/Machine/InstructionTheorems.v
+++ b/src/theories/Machine/InstructionTheorems.v
@@ -577,6 +577,13 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
       apply le_opp_mul_mul; lia.
       rewrite Znat.Nat2Z.inj_add, BinInt.Z.pow_add_r; try lia.
       apply lt_mul_mul; lia.
+      rewrite twos_complement_iso_2.
+      rewrite Znat.Nat2Z.inj_add, BinInt.Z.pow_add_r; try lia.
+      apply lt_opp_mul_mul; lia.
+      rewrite Znat.Nat2Z.inj_add, BinInt.Z.pow_add_r; try lia.
+      apply le_opp_mul_mul; lia.
+      rewrite Znat.Nat2Z.inj_add, BinInt.Z.pow_add_r; try lia.
+      apply lt_mul_mul; lia.
     Qed.
 
     Theorem pureOp_smulh_correct_sign (ri rj : regId) (A : Word) (m : MachineState) :

--- a/src/theories/Machine/InstructionTheorems.v
+++ b/src/theories/Machine/InstructionTheorems.v
@@ -345,7 +345,7 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
     (*"""
     compute [rj]u * [A]u and store least significant bits of result in ri
   
-    flag is set to 1 if [rj]u * [A]u ∈ U_W and to 0 otherwise.
+    flag is set to 1 if [rj]u * [A]u ∉ U_W and to 0 otherwise.
     """*)
     Definition pureOp_mull (ri rj : regId) (A : Word) :
       MachineState -> MachineState.
@@ -358,7 +358,7 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
       (* Registers *)
       - exact (replace registers0 ri resl).
       (* Flag *)
-      - exact (bv_eq resh (const b0 _)).
+      - exact (negb (bv_eq resh (const b0 _))).
       (* Memory *)
       - exact memory0.
       (* Main Tape *)
@@ -383,11 +383,12 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
 
     Theorem pureOp_mull_correct_flag (ri rj : regId) (A : Word) (m : MachineState) :
       flag (pureOp_mull ri rj A m) = 
-      ((bitvector_nat_big (nth (registers m) rj)
-      * bitvector_nat_big A) <? 2 ^ wordSize).
+      negb ((bitvector_nat_big (nth (registers m) rj)
+            * bitvector_nat_big A) <? 2 ^ wordSize).
     Proof. 
       destruct m; unfold pureOp_mull.
       destruct (splitat _ _) as [mh ml] eqn:sm; simpl.
+      f_equal.
       rewrite Bool.eq_iff_eq_true, bv_eq_equiv, ltb_lt, bv_mull_high_const0, sm.
       reflexivity.
     Qed.
@@ -411,7 +412,7 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
     (*"""
     compute [rj]u * [A]u and store most significant bits of result in ri
   
-    flag is set to 1 if [rj]u * [A]u ∈ U_W and to 0 otherwise.
+    flag is set to 1 if [rj]u * [A]u ∉ U_W and to 0 otherwise.
     """*)
     Definition pureOp_umulh (ri rj : regId) (A : Word) :
       MachineState -> MachineState.
@@ -424,7 +425,7 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
       (* Registers *)
       - exact (replace registers0 ri resh).
       (* Flag *)
-      - exact (bv_eq resh (const b0 _)).
+      - exact (negb (bv_eq resh (const b0 _))).
       (* Memory *)
       - exact memory0.
       (* Main Tape *)
@@ -449,11 +450,12 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
 
     Theorem pureOp_umulh_correct_flag (ri rj : regId) (A : Word) (m : MachineState) :
       flag (pureOp_umulh ri rj A m) = 
-      ((bitvector_nat_big (nth (registers m) rj)
-      * bitvector_nat_big A) <? 2 ^ wordSize).
+      negb ((bitvector_nat_big (nth (registers m) rj)
+            * bitvector_nat_big A) <? 2 ^ wordSize).
     Proof. 
       destruct m; unfold pureOp_umulh.
       destruct (splitat _ _) as [mh ml] eqn:sm; simpl.
+      f_equal.
       rewrite Bool.eq_iff_eq_true, bv_eq_equiv, ltb_lt, bv_mull_high_const0, sm.
       reflexivity.
     Qed.
@@ -510,12 +512,12 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
         exact (wuncast (sign :: resh)).
       (* Flag *)
       (*"""
-      flag is set to 1 if [rj]s x [A]s ∈ S_W and to 0 otherwise.
+      flag is set to 1 if [rj]s x [A]s ∉ S_W and to 0 otherwise.
       """ """
       S_W is the set of integers {-2^(W-1), ..., 0, 1, ..., 2^(W-1) - 1};
       """*)
-      - exact (andb (- 2 ^ (of_nat wordSize - 1) <=? mjA) 
-                    (mjA <? 2 ^ (of_nat wordSize - 1)))%Z.
+      - exact (negb (andb (- 2 ^ (of_nat wordSize - 1) <=? mjA) 
+                    (mjA <? 2 ^ (of_nat wordSize - 1)))%Z).
       (* Memory *)
       - exact memory0.
       (* Main Tape *)
@@ -605,9 +607,9 @@ Module TinyRAMInstThm (Params : TinyRAMParameters).
 
     Theorem pureOp_smulh_correct_flag (ri rj : regId) (A : Word) (m : MachineState) :
       flag (pureOp_smulh ri rj A m) = 
-      (andb (- 2 ^ (of_nat wordSize - 1) <=? 
-            (twos_complement (wcast (nth (registers m) rj)) * twos_complement (wcast A)))
-            (twos_complement (wcast (nth (registers m) rj)) * twos_complement (wcast A) <? 2 ^ (of_nat wordSize - 1)))%Z.
+      negb (andb (- 2 ^ (of_nat wordSize - 1) <=? 
+                 (twos_complement (wcast (nth (registers m) rj)) * twos_complement (wcast A)))
+                 (twos_complement (wcast (nth (registers m) rj)) * twos_complement (wcast A) <? 2 ^ (of_nat wordSize - 1)))%Z.
     Proof. 
       destruct m; unfold pureOp_smulh.
       destruct (splitat _ _) as [mh ml] eqn:sm; simpl.

--- a/src/theories/Utils/Arith.v
+++ b/src/theories/Utils/Arith.v
@@ -295,6 +295,14 @@ Proof.
   reflexivity.
 Qed.
 
+Theorem opp_lt_swap_l: forall n m : Z, lt (opp n) m <-> lt (opp m) n.
+Proof.
+  intros n m.
+  rewrite <- (BinInt.Z.opp_involutive m) at 1.
+  rewrite <- BinInt.Z.opp_lt_mono.
+  reflexivity.
+Qed.
+
 Theorem Z_inj_pow : forall x y, 
   pow (of_nat x) (of_nat y) = of_nat (x ^ y).
 Proof.
@@ -361,6 +369,27 @@ Proof.
     apply BinInt.Z.mul_le_mono_nonneg; lia.
   - rewrite opp_le_swap_l, <- BinInt.Z.mul_opp_r.
     apply BinInt.Z.mul_le_mono_nonneg; lia.
+Qed.
+
+Theorem lt_opp_mul_mul : forall p1 p2 t1 t2,
+  lt (opp p1) t1 -> lt (opp p2) t2 -> 
+  lt t1 p1 -> lt t2 p2 ->
+  lt (opp (mul p1 p2)) (mul t1 t2).
+Proof.
+  intros.
+  assert (lt Z0 p1); [ lia | ].
+  assert (lt Z0 p2); [ lia | ].
+  destruct (ltb t1 Z0) eqn:zt1; 
+  destruct (ltb t2 Z0) eqn:zt2;
+  try rewrite Z_ltb_lt in zt1;
+  try rewrite Z_ltb_lt in zt2;
+  try rewrite Z_nltb_ge in zt1;
+  try rewrite Z_nltb_ge in zt2;
+  try lia.
+  - rewrite opp_lt_swap_l, <- BinInt.Z.mul_opp_l.
+    apply BinInt.Z.mul_lt_mono_nonneg; lia.
+  - rewrite opp_lt_swap_l, <- BinInt.Z.mul_opp_r.
+    apply BinInt.Z.mul_lt_mono_nonneg; lia.
 Qed.
 
 Theorem lt_mul_mul : forall p1 p2 t1 t2,
@@ -497,3 +526,59 @@ Proof.
   rewrite N2Nat_inj_div;[|lia].
   now repeat rewrite Nat2N.id.
 Qed.
+
+
+Theorem mod_2_div : forall k, k mod 2 = 0 -> k / 2 = S k / 2.
+Proof.
+  assert (forall k,
+            (k mod 2 = 0 -> k / 2 = S k / 2) /\
+            (k mod 2 = 1 -> S k / 2 = S (S k) / 2));[|
+  intro k; destruct (H k); assumption].
+  induction k;[simpl;lia|destruct IHk];
+  split; intro.
+  - apply H0.
+    change k with (0 + k).
+    rewrite <- H1 at 1.
+    rewrite PeanoNat.Nat.add_mod_idemp_l;[|lia].
+    replace (S k + k) with (1 + 2 * k);[|lia].
+    rewrite <- PeanoNat.Nat.add_mod_idemp_r;[|lia].
+    rewrite PeanoNat.Nat.mul_comm, PeanoNat.Nat.mod_mul;simpl;lia.
+  - assert (forall k, S (S k) / 2 = S (k / 2));[
+        intro k2;change (S (S k2)) with (1 * 2 + k2);
+        rewrite PeanoNat.Nat.div_add_l; lia|].
+    repeat rewrite H2.
+    f_equal.
+    apply H.
+    change (S k) with (1 + k) in H1.
+    replace 0 with ((2 + k) mod 2) at 2;[|
+      replace (2 + k) with (1 + (1 + k));[|lia];
+      rewrite <- PeanoNat.Nat.add_mod_idemp_r, H1;
+      simpl; lia].
+    rewrite <- PeanoNat.Nat.add_mod_idemp_l; simpl; lia.
+Qed.
+
+Theorem nmod_2_0 : forall k, k mod 2 <> 0 -> k mod 2 = 1.
+Proof.
+  assert (forall k,
+            (k mod 2 <> 0 -> k mod 2 = 1) /\
+            (k mod 2 <> 1 -> k mod 2 = 0));[|
+  intro k; destruct (H k); assumption].
+  induction k;[simpl;lia|destruct IHk];
+  split; intro;
+  change (S k) with (1 + k);
+  rewrite <- PeanoNat.Nat.add_mod_idemp_r;
+  try lia.
+  - rewrite H0;[reflexivity|].
+    intro.
+    change (S k) with (1 + k) in H1.
+    rewrite <- PeanoNat.Nat.add_mod_idemp_r in H1.
+    rewrite H2 in H1; simpl in H1.
+    all: lia.
+  - rewrite H;[reflexivity|].
+    intro.
+    change (S k) with (1 + k) in H1.
+    rewrite <- PeanoNat.Nat.add_mod_idemp_r in H1.
+    rewrite H2 in H1; simpl in H1.
+    all: lia.
+Qed.
+

--- a/src/theories/Utils/Arith.v
+++ b/src/theories/Utils/Arith.v
@@ -527,6 +527,59 @@ Proof.
   now repeat rewrite Nat2N.id.
 Qed.
 
+Theorem N2Nat_inj_lt:
+  forall n m : N, (n < m)%N <-> (N.to_nat n < N.to_nat m)%nat.
+Proof.
+ destruct n as [|p], m as [|p']; simpl.
+ - split.
+   + intro H.
+     apply (N.lt_irrefl _) in H.
+     contradiction.
+   + intro H.
+     apply (lt_irrefl _) in H.
+     contradiction.
+ - destruct (Pos2Nat.is_succ p') as (n,->).
+   split.
+   + intro H.
+     apply lt_0_succ.
+   + intro H.
+     now apply (N.ltb_lt 0 (N.pos p')).
+ - destruct (Pos2Nat.is_succ p) as (n,->).
+   split.
+   + intro H.
+     apply (N.ltb_lt (N.pos p) 0) in H.
+     inversion H.
+   + intro H.
+     apply (ltb_lt (S n) 0) in H.
+     inversion H.
+ - apply Pos2Nat.inj_lt.
+Qed.
+
+Theorem N2Nat_inj_le:
+  forall n m : N, (n <= m)%N <-> (N.to_nat n <= N.to_nat m)%nat.
+Proof.
+ destruct n as [|p], m as [|p']; simpl.
+ - split.
+   + intro H.
+     apply le_refl.
+   + intro H.
+     apply N.le_refl.
+ - destruct (Pos2Nat.is_succ p') as (n,->).
+   split.
+   + intro H.
+     apply le_0_l.
+   + intro H.
+     now apply (N.leb_le 0 (N.pos p')).
+ - destruct (Pos2Nat.is_succ p) as (n,->).
+   split.
+   + intro H.
+     apply (N.leb_le (N.pos p) 0) in H.
+     inversion H.
+   + intro H.
+     apply (leb_le (S n) 0) in H.
+     inversion H.
+ - apply Pos2Nat.inj_le.
+Qed.
 
 Theorem mod_2_div : forall k, k mod 2 = 0 -> k / 2 = S k / 2.
 Proof.


### PR DESCRIPTION
Factor out references to unary natural numbers in integer arithmetic.

Closes #12 